### PR TITLE
deprecate: publish tombstone release 0.0.11 to retire mkdocs-macros-utils

### DIFF
--- a/README_PyPI.md
+++ b/README_PyPI.md
@@ -1,5 +1,8 @@
 # mkdocs-macros-utils
 
+> **Deprecated:** This package is no longer maintained.
+> Please migrate to **[zensical-macros-utils](https://pypi.org/project/zensical-macros-utils/)** instead.
+
 [mkdocs-macros-utils](https://7rikazhexde.github.io/mkdocs-macros-utils/) is a [zensical](https://zensical.org/)-based project that provides macros to extend cards, code blocks, etc, in MkDocs documents.
 
 [![pages-build-deployment](https://github.com/7rikazhexde/mkdocs-macros-utils/actions/workflows/pages/pages-build-deployment/badge.svg?branch=gh-pages)](https://github.com/7rikazhexde/mkdocs-macros-utils/actions/workflows/pages/pages-build-deployment) [![DOCS](https://img.shields.io/badge/Docs-Click%20Here-blue?colorA=24292e&colorB=0366d6&logo=github)](https://7rikazhexde.github.io/mkdocs-macros-utils/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,10 @@
 # mkdocs-macros-utils
 
-[mkdocs-macros-utils](https://pypi.org/project/mkdocs-macros-utils/) is [mkdocs-macros-plugin](https://mkdocs-macros-plugin.readthedocs.io/en/latest/) based project that provides macros to extend cards, code blocks, etc, in MkDocs documents.
+!!! warning "Deprecated"
+
+    This package is no longer maintained. Please migrate to **[zensical-macros-utils](https://pypi.org/project/zensical-macros-utils/)**.
+
+[mkdocs-macros-utils](https://pypi.org/project/mkdocs-macros-utils/) is a [zensical](https://zensical.org/)-based project that provides macros to extend cards, code blocks, etc, in MkDocs documents.
 
 ## Features
 
@@ -18,44 +22,40 @@
     pip install mkdocs-macros-utils
     ```
 
-!!! info "For poetry"
+!!! info "For uv"
 
     ```bash
-    poetry add mkdocs-macros-utils
+    uv add mkdocs-macros-utils
     ```
 
 ### Config settings
 
-1. Add the plugin to your `mkdocs.yml`
+1. Add the extension to your `zensical.toml`
 
-    ```yaml
-    plugins:
-      - macros:
-          modules: [mkdocs_macros_utils]
+    ```toml
+    extra_css = [
+        "stylesheets/macros-utils/link-card.css",
+        "stylesheets/macros-utils/gist-cb.css",
+        "stylesheets/macros-utils/x-twitter-link-card.css",
+    ]
 
-    markdown_extensions:
-      - attr_list
-      - md_in_html
+    extra_javascript = [
+        "javascripts/macros-utils/x-twitter-widget.js",
+    ]
 
-    extra:
-      debug:
-        link_card: false  # Set to true for debug logging
-        gist_codeblock: false
-        x_twitter_card: false
+    [project.plugins.macros]
+    modules = ["mkdocs_macros_utils"]
 
-    extra_css:
-      - stylesheets/macros-utils/link-card.css
-      - stylesheets/macros-utils/gist-cb.css
-      - stylesheets/macros-utils/x-twitter-link-card.css
-
-    extra_javascript:
-      - javascripts/macros-utils/x-twitter-widget.js
+    [project.extra.debug]
+    link_card = false
+    gist_codeblock = false
+    x_twitter_card = false
     ```
 
 1. Start the development server
 
     ```bash
-    poetry run mkdocs serve
+    uv run zensical serve
     ```
 
 The plugin will automatically create the required directories and copy CSS/JS files during the build process.

--- a/mkdocs_macros_utils/__init__.py
+++ b/mkdocs_macros_utils/__init__.py
@@ -2,6 +2,16 @@
 Zensical macros module for enhanced documentation components.
 """
 
+import warnings
+
+warnings.warn(
+    "mkdocs-macros-utils is deprecated and will no longer be maintained. "
+    "Please migrate to zensical-macros-utils: "
+    "https://pypi.org/project/zensical-macros-utils/",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 from pathlib import Path
 import shutil
 import logging

--- a/mkdocs_macros_utils/__init__.py
+++ b/mkdocs_macros_utils/__init__.py
@@ -2,7 +2,18 @@
 Zensical macros module for enhanced documentation components.
 """
 
+import logging
+import os
+import shutil
 import warnings
+from pathlib import Path
+from typing import Any, Dict
+
+from zensical.extensions.macros import MacroEnv
+
+from . import gist_codeblock
+from . import link_card
+from . import x_twitter_card
 
 warnings.warn(
     "mkdocs-macros-utils is deprecated and will no longer be maintained. "
@@ -11,17 +22,6 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=2,
 )
-
-from pathlib import Path
-import shutil
-import logging
-import os
-from typing import Any, Dict
-from zensical.extensions.macros import MacroEnv
-
-from . import link_card
-from . import gist_codeblock
-from . import x_twitter_card
 
 logger = logging.getLogger("zensical.macros-utils")
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mkdocs-macros-utils",
-  "version": "0.0.9",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mkdocs-macros-utils",
-      "version": "0.0.9",
+      "version": "0.0.11",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.29.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mkdocs-macros-utils",
-  "version": "0.0.9",
-  "description": "`mkdocs-macros-utils` is [mkdocs-macros-plugin](https://mkdocs-macros-plugin.readthedocs.io/en/latest/) based project that provides macros to extend cards, code blocks, etc, in MkDocs documents.",
+  "version": "0.0.11",
+  "description": "`mkdocs-macros-utils` is a deprecated package. Please migrate to zensical-macros-utils.",
   "main": "index.js",
   "directories": {
     "doc": "docs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mkdocs-macros-utils"
-version = "0.0.10"
+version = "0.0.11"
 description = "mkdocs-macros-utils is a zensical-based project that provides macros to extend cards, code blocks, etc, in MkDocs documents."
 authors = [
     {name = "7rikazhexde", email = "33836132+7rikazhexde@users.noreply.github.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -574,7 +574,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-macros-utils"
-version = "0.0.9"
+version = "0.0.11"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

- Bump version `0.0.10` → `0.0.11` (`pyproject.toml`, `package.json`, `package-lock.json`)
- Add `DeprecationWarning` on import pointing to `zensical-macros-utils`
- Add deprecation banner to `README_PyPI.md`
- Update `docs/index.md`: Poetry → uv、mkdocs.yml → zensical.toml 形式、非推奨 admonition 追加

## Background

v0.0.10 で zensical + uv への移行が完了。今後は `zensical-macros-utils` (v0.10.0) として新規公開するため、本パッケージを tombstone リリースで正式に非推奨化する。

Closes #200

## Test plan

- [x] `pre-commit run --all-files` が全フック通過済み
- [ ] マージ後: `uv build && uv publish` で PyPI に v0.0.11 を公開

🤖 Generated with [Claude Code](https://claude.com/claude-code)