### PR TITLE
fix(js): prevent duplicate Twitter card render on reload

### DIFF
--- a/docs/javascripts/macros-utils/x-twitter-widget.js
+++ b/docs/javascripts/macros-utils/x-twitter-widget.js
@@ -157,6 +157,20 @@
       return;
     }
 
+    // Guard against concurrent renders of the same container. createTweet is
+    // async — it only appends its iframe after the returned promise resolves —
+    // so two overlapping calls (e.g. the Twitter script's onload and the
+    // window 'load' event firing close together on reload) would each append
+    // an iframe and produce duplicate cards. While a render is in flight we
+    // record that another was requested and run it once afterwards, so a theme
+    // change that arrives mid-render still takes effect.
+    if (container.__xTwitterRendering) {
+      log("Render already in progress, queuing re-render");
+      container.__xTwitterPending = true;
+      return;
+    }
+    container.__xTwitterRendering = true;
+
     const theme = getColorScheme();
     const width = computeWidth(container);
     log("Rendering tweet", tweetId, "theme:", theme, "width:", width);
@@ -170,7 +184,14 @@
         align: "center",
       })
       .then(() => log("Tweet rendered successfully"))
-      .catch((err) => log("Error rendering tweet:", err));
+      .catch((err) => log("Error rendering tweet:", err))
+      .then(() => {
+        container.__xTwitterRendering = false;
+        if (container.__xTwitterPending) {
+          container.__xTwitterPending = false;
+          renderTweet(container);
+        }
+      });
   }
 
   /**
@@ -210,18 +231,10 @@
   /**
    * Ensure the Twitter widgets script is loaded, then run the callback.
    * Uses a preconnect hint to speed up the initial connection.
-   * @param {Function} onReady - Callback to run once widgets are available.
    */
   function loadWidgetScript() {
-    // If the script is already loaded and ready, do nothing.
-    if (window.twttr && window.twttr.widgets) {
-      log("Twitter widgets already available");
-      return;
-    }
-
-    // Avoid injecting the script twice.
     if (document.querySelector(`script[src="${TWITTER_SCRIPT_SRC}"]`)) {
-      log("Twitter script already loading");
+      log("Twitter script already loading or loaded");
       return;
     }
 
@@ -234,6 +247,10 @@
     const script = document.createElement("script");
     script.src = TWITTER_SCRIPT_SRC;
     script.async = true;
+    script.onload = () => {
+      log("Twitter script loaded, rendering tweets");
+      whenReady(renderAllTweets);
+    };
     script.onerror = (err) => log("Failed to load Twitter script:", err);
     document.head.appendChild(script);
   }
@@ -243,15 +260,21 @@
    */
   function setupColorSchemeObserver() {
     log("Setting up color scheme observer");
+
+    // Disconnect any observer from a previous initialization so repeated
+    // setup (a duplicate script include, or re-init in tests) does not stack
+    // observers that all re-render on every theme change.
+    if (window.__xTwitterSchemeObserver) {
+      window.__xTwitterSchemeObserver.disconnect();
+    }
+
     const debouncedRender = debounce(renderAllTweets, 100);
 
-    const observer = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        if (mutation.attributeName === "data-md-color-scheme") {
-          log("Color scheme mutation detected");
-          debouncedRender();
-        }
-      });
+    // attributeFilter below restricts deliveries to data-md-color-scheme, so
+    // every mutation we receive is a theme change worth re-rendering for.
+    const observer = new MutationObserver(() => {
+      log("Color scheme mutation detected");
+      debouncedRender();
     });
 
     observer.observe(document.documentElement, {
@@ -262,6 +285,7 @@
       attributes: true,
       attributeFilter: ["data-md-color-scheme"],
     });
+    window.__xTwitterSchemeObserver = observer;
 
     const palette = document.querySelector('[data-md-component="palette"]');
     if (palette) {
@@ -280,16 +304,24 @@
    */
   function start() {
     setupColorSchemeObserver();
-    // Load the script but don't render yet.
-    loadWidgetScript();
-    // Render only on window.load, ensuring all assets and scripts are ready.
-    window.addEventListener("load", () => {
-      whenReady(renderAllTweets);
-    });
+    if (!(window.twttr && window.twttr.widgets)) {
+      loadWidgetScript();
+    }
+    // Bind the load handler idempotently: replace any handler from a previous
+    // initialization so window 'load' triggers a single render, not one per
+    // (accidental) script include.
+    if (window.__xTwitterLoadHandler) {
+      window.removeEventListener("load", window.__xTwitterLoadHandler);
+    }
+    window.__xTwitterLoadHandler = () => whenReady(renderAllTweets);
+    window.addEventListener("load", window.__xTwitterLoadHandler);
   }
 
   /**
    * Entry point: wait for the DOM if necessary, then start.
+   *
+   * Safe to run more than once (e.g. a duplicate script include): start()
+   * rebinds its load handler and observer idempotently rather than stacking.
    */
   function initialize() {
     log("Starting initialization");

--- a/scripts/verify_config_loading.py
+++ b/scripts/verify_config_loading.py
@@ -17,7 +17,10 @@ from pathlib import Path
 _ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(_ROOT))
 
-from zensical_macros_utils.common import load_config, load_extra_config
+from zensical_macros_utils.common import (  # noqa: E402  # sys.path 調整後にインポートする必要がある
+    load_config,
+    load_extra_config,
+)
 
 CONFIG_CANDIDATES = ["zensical.toml", "mkdocs.yml", "mkdocs.yaml"]
 

--- a/tests/js/x-twitter-widget.test.js
+++ b/tests/js/x-twitter-widget.test.js
@@ -357,6 +357,22 @@ describe("X/Twitter widget", () => {
     appendSpy.mockRestore();
   });
 
+  test("does not inject a second script when one is already present", () => {
+    delete global.twttr;
+    const existing = document.createElement("script");
+    existing.src = "https://platform.twitter.com/widgets.js";
+    document.head.appendChild(existing);
+
+    const appendSpy = jest.spyOn(document.head, "appendChild");
+    loadModule();
+
+    const injectedScripts = appendSpy.mock.calls
+      .map((c) => c[0])
+      .filter((el) => el.tagName === "SCRIPT");
+    expect(injectedScripts).toHaveLength(0);
+    appendSpy.mockRestore();
+  });
+
   test("renders after the script finishes loading", () => {
     delete global.twttr;
     const appendSpy = jest.spyOn(document.head, "appendChild");
@@ -369,7 +385,6 @@ describe("X/Twitter widget", () => {
     const createTweet = createTweetMock();
     global.twttr = { widgets: { createTweet }, ready: (cb) => cb() };
     script.onload();
-    window.dispatchEvent(new Event("load"));
 
     expect(createTweet).toHaveBeenCalledWith(
       TWEET_ID,
@@ -413,7 +428,6 @@ describe("X/Twitter widget", () => {
     const ready = jest.fn((cb) => cb());
     global.twttr = { widgets: { createTweet }, ready };
     script.onload();
-    window.dispatchEvent(new Event("load"));
 
     expect(ready).toHaveBeenCalled();
     expect(createTweet).toHaveBeenCalled();
@@ -422,7 +436,7 @@ describe("X/Twitter widget", () => {
 
   // -- Observers & handlers -------------------------------------------------
 
-  test("re-renders on palette change events", () => {
+  test("re-renders on palette change events", async () => {
     document.body.innerHTML = `
       <div class="x-twitter-embed" data-url="${TWEET_URL}" data-tweet-id="${TWEET_ID}"></div>
       <form data-md-component="palette">
@@ -431,10 +445,29 @@ describe("X/Twitter widget", () => {
     `;
     loadModule();
     window.dispatchEvent(new Event("load"));
+    // Let the initial render settle so the in-flight guard clears before the
+    // palette change requests a re-render.
+    await flush();
     const callsBefore = global.twttr.widgets.createTweet.mock.calls.length;
 
     const palette = document.querySelector('[data-md-component="palette"]');
     palette.dispatchEvent(new Event("change"));
+    jest.advanceTimersByTime(100);
+
+    expect(
+      global.twttr.widgets.createTweet.mock.calls.length
+    ).toBeGreaterThan(callsBefore);
+  });
+
+  test("re-renders when the color-scheme attribute mutates", async () => {
+    loadModule();
+    window.dispatchEvent(new Event("load"));
+    await flush();
+    const callsBefore = global.twttr.widgets.createTweet.mock.calls.length;
+
+    // Mutating the observed attribute should drive the MutationObserver.
+    document.documentElement.setAttribute("data-md-color-scheme", "slate");
+    await flush();
     jest.advanceTimersByTime(100);
 
     expect(
@@ -449,6 +482,43 @@ describe("X/Twitter widget", () => {
     window.dispatchEvent(new Event("load"));
 
     expect(global.twttr.widgets.createTweet).toHaveBeenCalledTimes(1);
+  });
+
+  test("queues a re-render requested while one is in flight (no duplicates)", async () => {
+    // First render returns a promise we control so it stays "in flight" while
+    // a second render is requested; the second must be queued, not run
+    // immediately, otherwise two iframes would be appended (the reload bug).
+    let resolveFirst;
+    const createTweet = jest
+      .fn()
+      .mockImplementationOnce(
+        () => new Promise((resolve) => (resolveFirst = resolve))
+      )
+      .mockResolvedValue({});
+    global.twttr = { widgets: { createTweet }, ready: (cb) => cb() };
+
+    document.body.innerHTML = `
+      <div class="x-twitter-embed" data-url="${TWEET_URL}" data-tweet-id="${TWEET_ID}"></div>
+      <form data-md-component="palette">
+        <input type="radio" data-md-color-scheme="default" checked>
+      </form>
+    `;
+
+    loadModule();
+    window.dispatchEvent(new Event("load"));
+    expect(createTweet).toHaveBeenCalledTimes(1);
+
+    // Request a second render while the first is still pending.
+    const palette = document.querySelector('[data-md-component="palette"]');
+    palette.dispatchEvent(new Event("change"));
+    jest.advanceTimersByTime(100);
+    // Still only one call — the second render was queued, not executed.
+    expect(createTweet).toHaveBeenCalledTimes(1);
+
+    // Resolving the first render flushes the queued one exactly once.
+    resolveFirst({});
+    await flush();
+    expect(createTweet).toHaveBeenCalledTimes(2);
   });
 
   // -- Initialization -------------------------------------------------------

--- a/zensical_macros_utils/static/js/x-twitter-widget.js
+++ b/zensical_macros_utils/static/js/x-twitter-widget.js
@@ -157,6 +157,20 @@
       return;
     }
 
+    // Guard against concurrent renders of the same container. createTweet is
+    // async — it only appends its iframe after the returned promise resolves —
+    // so two overlapping calls (e.g. the Twitter script's onload and the
+    // window 'load' event firing close together on reload) would each append
+    // an iframe and produce duplicate cards. While a render is in flight we
+    // record that another was requested and run it once afterwards, so a theme
+    // change that arrives mid-render still takes effect.
+    if (container.__xTwitterRendering) {
+      log("Render already in progress, queuing re-render");
+      container.__xTwitterPending = true;
+      return;
+    }
+    container.__xTwitterRendering = true;
+
     const theme = getColorScheme();
     const width = computeWidth(container);
     log("Rendering tweet", tweetId, "theme:", theme, "width:", width);
@@ -170,7 +184,14 @@
         align: "center",
       })
       .then(() => log("Tweet rendered successfully"))
-      .catch((err) => log("Error rendering tweet:", err));
+      .catch((err) => log("Error rendering tweet:", err))
+      .then(() => {
+        container.__xTwitterRendering = false;
+        if (container.__xTwitterPending) {
+          container.__xTwitterPending = false;
+          renderTweet(container);
+        }
+      });
   }
 
   /**
@@ -239,15 +260,21 @@
    */
   function setupColorSchemeObserver() {
     log("Setting up color scheme observer");
+
+    // Disconnect any observer from a previous initialization so repeated
+    // setup (a duplicate script include, or re-init in tests) does not stack
+    // observers that all re-render on every theme change.
+    if (window.__xTwitterSchemeObserver) {
+      window.__xTwitterSchemeObserver.disconnect();
+    }
+
     const debouncedRender = debounce(renderAllTweets, 100);
 
-    const observer = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        if (mutation.attributeName === "data-md-color-scheme") {
-          log("Color scheme mutation detected");
-          debouncedRender();
-        }
-      });
+    // attributeFilter below restricts deliveries to data-md-color-scheme, so
+    // every mutation we receive is a theme change worth re-rendering for.
+    const observer = new MutationObserver(() => {
+      log("Color scheme mutation detected");
+      debouncedRender();
     });
 
     observer.observe(document.documentElement, {
@@ -258,6 +285,7 @@
       attributes: true,
       attributeFilter: ["data-md-color-scheme"],
     });
+    window.__xTwitterSchemeObserver = observer;
 
     const palette = document.querySelector('[data-md-component="palette"]');
     if (palette) {
@@ -279,17 +307,23 @@
     if (!(window.twttr && window.twttr.widgets)) {
       loadWidgetScript();
     }
-    window.addEventListener("load", () => whenReady(renderAllTweets));
+    // Bind the load handler idempotently: replace any handler from a previous
+    // initialization so window 'load' triggers a single render, not one per
+    // (accidental) script include.
+    if (window.__xTwitterLoadHandler) {
+      window.removeEventListener("load", window.__xTwitterLoadHandler);
+    }
+    window.__xTwitterLoadHandler = () => whenReady(renderAllTweets);
+    window.addEventListener("load", window.__xTwitterLoadHandler);
   }
 
   /**
    * Entry point: wait for the DOM if necessary, then start.
+   *
+   * Safe to run more than once (e.g. a duplicate script include): start()
+   * rebinds its load handler and observer idempotently rather than stacking.
    */
-  let initialized = false;
   function initialize() {
-    if (initialized) return;
-    initialized = true;
-
     log("Starting initialization");
     if (document.readyState === "loading") {
       log("Document still loading, waiting for DOMContentLoaded");


### PR DESCRIPTION
## 問題

デプロイ済みサイトで X/Twitter カードを含むページを**リロード**すると、カードが2つ表示される。`uv run zensical serve`（および初回アクセス時）では1つ。ダーク/ライト切替時も1つ。

例: https://7rikazhexde.github.io/zensical-macros-utils/examples/x-twitter-card-macro/

## 原因

`renderTweet()` の `twttr.widgets.createTweet()` は**非同期**で、iframe は Promise 解決後に追加される。初回描画のトリガーが2つあり:

1. `loadWidgetScript()` の `script.onload`
2. `window` の `load` イベント

リロード時は `widgets.js` がキャッシュ済みで `script.onload` が速く発火し、`window.load` とほぼ同時になる。両者が `innerHTML=""` でクリア → それぞれ `createTweet` 開始（互いの iframe 追加前）→ **iframe が2つ追加**される。テーマ切替は debounce で1回に集約されるため影響を受けなかった。

## 修正

- **コンテナ単位のレンダリング中フラグ**を導入。進行中なら再描画を保留し、完了後に1回だけ実行。テーマ変更が描画中に来ても重複なく反映される。
- `window` の `load` ハンドラと `MutationObserver` を**冪等にバインド**（`window` に保持し、再初期化時は差し替え）。スクリプト重複読み込み時の多重バインドも防止。
- `attributeFilter` で属性が限定されているオブザーバーコールバックを簡素化し、冗長になったモジュールレベルの初期化ガードを削除。

## その他

- `docs/` の静的コピーをソースと同期。
- 保留キュー / スクリプト既存時の早期return / 属性変更による再描画のテストを追加。**JSカバレッジは全指標100%（40テスト）**。
- `scripts/verify_config_loading.py`: `sys.path` 調整後に必要なインポートの Ruff E402 を抑制。

## テスト

- [x] `node node_modules/jest/bin/jest.js --coverage` → 40 passed, 100% (statements/branches/functions/lines)
- [x] `uv run ruff check` / `ruff format --check` 通過
- [ ] デプロイ後、対象ページをリロードしてカードが1つだけ表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)