### PR TITLE
:memo: docs: update CLAUDE.md for 100% coverage, common.py, and release process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,8 @@ just test-ci-xml    # XML report (for CI)
 just test-ci-term   # Terminal report (for CI)
 ```
 
-Coverage requirement: **90% minimum** enforced on PRs.
+Coverage requirement: **100%** for both pytest and Jest, enforced on PRs
+(pytest `fail_under = 100`; Jest `coverageThreshold` 100% on all metrics).
 
 ### JavaScript Tests
 
@@ -64,17 +65,42 @@ pre-commit run --all-files      # Run all hooks
 
 mypy is configured with `disallow_untyped_defs = true` — all functions must be fully annotated.
 
+## Release & Commit Conventions
+
+Commits follow **gitmoji** (`:sparkles:` feature, `:bug:` fix, `:boom:` breaking,
+`:memo:` docs, ...). The leading `:shortcode:` drives automated releases — see
+[CONTRIBUTING.md](CONTRIBUTING.md) for the gitmoji → version-bump table.
+
+Releasing is two steps (the PyPI token never lives in CI):
+
+1. Run the **semantic-release** workflow (`Actions → semantic-release`, manual
+   `workflow_dispatch`; set `dry_run` to preview). It computes the next version
+   from gitmoji, bumps `pyproject.toml`/`package.json`, re-locks `uv.lock`,
+   updates `CHANGELOG.md`, commits to `main`, and creates the `vX.Y.Z` tag +
+   GitHub Release. Config: `.releaserc.cjs` + `.github/release-notes-template.hbs`.
+2. Publish to PyPI locally: `uv run python scripts/publish_to_pypi.py` (token read
+   from the OS keyring via `uv publish --keyring-provider subprocess`; no env var).
+
+Dependabot PRs are gated by `dependency-review.yml`, labelled by
+`dependabot-metadata.yml`, and kept current by `dependabot-auto-rebase.yml`;
+merging stays manual. All GitHub Actions are pinned to commit SHAs.
+
 ## Architecture
 
 ### Module Lifecycle (`zensical_macros_utils/__init__.py`)
 
 The module exports `define_env(env: MacroEnv)` called by zensical's macros extension:
 
-- Reads `zensical.toml` (via `_load_config()`) to get `docs_dir`, `site_url`, and `extra` settings
-- Copies CSS/JS static assets into `docs/` via `copy_static_files()` (skips if already up-to-date)
+- Loads config via `common.load_config()`, which reads `zensical.toml` first and
+  falls back to `mkdocs.yml` / `mkdocs.yaml` in the CWD, to get `site_url` and `extra` settings
+- Copies CSS/JS static assets into `docs/` via `common.copy_static_files()` (skips if already up-to-date)
 - Registers the three macros by calling each sub-module's `define_env`
 
-Use `MACROS_UTILS_DOCS_DIR` env var to override the default `docs/` target directory.
+Framework-agnostic helpers live in `common.py`: `load_config()`,
+`load_extra_config()`, `get_docs_dir()` (honours the `MACROS_UTILS_DOCS_DIR` env
+var, default `docs/`), `copy_static_files()`, and `escape_html()`. `__init__.py`
+re-exports them as `_load_config` / `_load_extra_config` / `_get_docs_dir` and
+focuses on orchestration.
 
 ### Macro Modules
 
@@ -83,7 +109,7 @@ Use `MACROS_UTILS_DOCS_DIR` env var to override the default `docs/` target direc
 | `link_card.py` | `link_card(url, ...)` | Fetches SVG icons (from GitHub Gists), renders an HTML link card with image/SVG, domain, and description. Uses `env.variables["_site_url"]` for base URL. |
 | `gist_codeblock.py` | `gist_codeblock(gist_url, ...)` | Fetches raw Gist content via GitHub API, auto-detects language via filename extension and Pygments, returns a fenced Markdown code block |
 | `x_twitter_card.py` | `x_twitter_card(url)` | Normalizes x.com/twitter.com URLs and renders a Twitter embed widget with dark mode support |
-| `debug_logger.py` | (internal) | Per-feature debug logging controlled by `extra.debug.{link_card,gist_codeblock,x_twitter_card}` in `mkdocs.yml`. Read via `env.variables["extra"]` set by `define_env`. |
+| `debug_logger.py` | (internal) | Per-feature debug logging controlled by `extra.debug.{link_card,gist_codeblock,x_twitter_card}` in `zensical.toml` (or `mkdocs.yml`). Read via `env.variables["extra"]` set by `define_env`. |
 
 ### Tests (`tests/python/`)
 


### PR DESCRIPTION
最近のCI/CD・アーキテクチャ変更に合わせて `CLAUDE.md` を更新しました。docs サイト・README・他のmdに古い記述がないことも確認済み（該当は `CLAUDE.md` のみ）。

## 変更点

- **カバレッジ要件**: 90% → **100%**（pytest `fail_under=100`、Jest `coverageThreshold` 100%）
- **Module Lifecycle**: 設定読み込みが `common.load_config()` 経由になり、`zensical.toml` → `mkdocs.yml` → `mkdocs.yaml` のフォールバックに対応。`common.py` の共通ヘルパー（`load_config` / `load_extra_config` / `get_docs_dir` / `copy_static_files` / `escape_html`）を明記
- **新規セクション「Release & Commit Conventions」**: gitmojiコミット規約、2段階リリース（semantic-release + ローカルkeyringでのPyPI公開）、Dependabotゲートを記載（[CONTRIBUTING.md](CONTRIBUTING.md) を参照）
- debug設定の場所を `zensical.toml`（または `mkdocs.yml`）に修正

## 検証

- [x] pre-commit 通過
- [x] `*.md` 全体をグレップし、古い記述（90% / 旧リリースワークフロー / UV_PUBLISH_TOKEN 等）が残っていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)